### PR TITLE
Netlify custom domain redirect prep

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+# Redirect default Netlify subdomain to primary domain
+# http://fractal-docs.netlify.com/* http://fractal.build/:splat 301!


### PR DESCRIPTION
Redirect default Netlify subdomain to primary domain, uncomment when DNS settings have been updated